### PR TITLE
Refactor stubs for `marked.js`.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -338,10 +338,7 @@ export function render_and_show_preview($preview_spinner, $preview_content_box, 
             // wrong, users will see a brief flicker of the locally
             // echoed frontend rendering before receiving the
             // authoritative backend rendering from the server).
-            const message_obj = {
-                raw_content: content,
-            };
-            markdown.apply_markdown(message_obj);
+            markdown.apply_markdown({raw_content: content});
         }
         channel.post({
             url: "/json/messages/render",

--- a/web/src/drafts.js
+++ b/web/src/drafts.js
@@ -345,7 +345,7 @@ export function format_draft(draft) {
     }
 
     try {
-        markdown.apply_markdown(formatted);
+        formatted = markdown.apply_markdown(formatted);
     } catch (error) {
         // In the unlikely event that there is syntax in the
         // draft content which our Markdown processor is

--- a/web/src/echo.js
+++ b/web/src/echo.js
@@ -174,12 +174,12 @@ export function insert_local_message(message_request, local_id_float, insert_new
     // Shallow clone of message request object that is turned into something suitable
     // for zulip.js:add_message
     // Keep this in sync with changes to compose.create_message_object
-    const message = {...message_request};
+    let message = {...message_request};
 
     message.raw_content = message.content;
 
     // NOTE: This will parse synchronously. We're not using the async pipeline
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
 
     message.content_type = "text/html";
     message.sender_email = people.my_current_email();
@@ -189,7 +189,7 @@ export function insert_local_message(message_request, local_id_float, insert_new
     message.local_id = local_id_float.toString();
     message.locally_echoed = true;
     message.id = local_id_float;
-    markdown.add_topic_links(message);
+    message.topic_links = markdown.get_topic_links_web(message.topic);
 
     waiting_for_id.set(message.local_id, message);
     waiting_for_ack.set(message.local_id, message);
@@ -315,7 +315,7 @@ export function edit_locally(message, request) {
             // all flags, so we need to restore those flags that are
             // properties of how the user has interacted with the
             // message, and not its rendering.
-            markdown.apply_markdown(message);
+            message = markdown.apply_markdown(message);
             if (request.starred !== undefined) {
                 message.starred = request.starred;
             }

--- a/web/src/info_overlay.js
+++ b/web/src/info_overlay.js
@@ -236,8 +236,7 @@ Coffee`,
 export function set_up_toggler() {
     for (const row of markdown_help_rows) {
         if (row.markdown && !row.output_html) {
-            const message = {raw_content: row.markdown};
-            markdown.apply_markdown(message);
+            const message = markdown.apply_markdown({raw_content: row.markdown});
             row.output_html = util.clean_user_content_links(message.content);
         }
     }

--- a/web/src/linkifiers.ts
+++ b/web/src/linkifiers.ts
@@ -2,7 +2,7 @@ import url_template_lib from "url-template";
 
 import * as blueslip from "./blueslip";
 
-type LinkifierMap = Map<
+export type LinkifierMap = Map<
     RegExp,
     {url_template: url_template_lib.Template; group_number_to_name: Record<number, string>}
 >;

--- a/web/src/markdown_config.ts
+++ b/web/src/markdown_config.ts
@@ -1,8 +1,7 @@
-import type url_template_lib from "url-template";
-
 import * as emoji from "./emoji";
 import * as hash_util from "./hash_util";
 import * as linkifiers from "./linkifiers";
+import type {MarkdownHelpers} from "./markdown";
 import * as people from "./people";
 import * as stream_data from "./stream_data";
 import type {Stream} from "./sub_store";
@@ -30,55 +29,6 @@ import {user_settings} from "./user_settings";
     follow the convention of returning `undefined`
     when the lookups fail.
 */
-
-// TODO/typescript: Move this to markdown
-type AbstractMap<K, V> = {
-    keys: () => Iterator<K>;
-    entries: () => Iterator<[K, V]>;
-    get: (k: K) => V | undefined;
-};
-
-// TODO/typescript: Move this to markdown
-type MarkdownHelpers = {
-    // user stuff
-    get_actual_name_from_user_id: (user_id: number) => string | undefined;
-    get_user_id_from_name: (full_name: string) => number | undefined;
-    is_valid_full_name_and_user_id: (full_name: string, user_id: number) => boolean;
-    my_user_id: () => number;
-    is_valid_user_id: (user_id: number) => boolean;
-
-    // user groups
-    get_user_group_from_name: (name: string) => {id: number; name: string} | undefined;
-    is_member_of_user_group: (user_id: number, user_group_id: number) => boolean;
-
-    // stream hashes
-    get_stream_by_name: (stream_name: string) => {stream_id: number; name: string} | undefined;
-    stream_hash: (stream_id: number) => string;
-    stream_topic_hash: (stream_id: number, topic: string) => string;
-
-    // settings
-    should_translate_emoticons: () => boolean;
-
-    // emojis
-    get_emoji_name: (codepoint: string) => string | undefined;
-    get_emoji_codepoint: (emoji_name: string) => string | undefined;
-    get_emoticon_translations: () => {regex: RegExp; replacement_text: string}[];
-    get_realm_emoji_url: (emoji_name: string) => string | undefined;
-
-    // linkifiers
-    get_linkifier_map: () => AbstractMap<
-        RegExp,
-        {url_template: url_template_lib.Template; group_number_to_name: Record<number, string>}
-    >;
-};
-
-function abstract_map<K, V>(map: Map<K, V>): AbstractMap<K, V> {
-    return {
-        keys: () => map.keys(),
-        entries: () => map.entries(),
-        get: (k) => map.get(k),
-    };
-}
 
 function stream(obj: Stream | undefined): {stream_id: number; name: string} | undefined {
     if (obj === undefined) {
@@ -113,11 +63,12 @@ export const get_helpers = (): MarkdownHelpers => ({
     is_valid_user_id: people.is_known_user_id,
 
     // user groups
-    get_user_group_from_name: (name) => user_group(user_groups.get_user_group_from_name(name)),
+    get_user_group_from_name: (name: string) =>
+        user_group(user_groups.get_user_group_from_name(name)),
     is_member_of_user_group: user_groups.is_direct_member_of,
 
     // stream hashes
-    get_stream_by_name: (name) => stream(stream_data.get_sub(name)),
+    get_stream_by_name: (name: string) => stream(stream_data.get_sub(name)),
     stream_hash: hash_util.by_stream_url,
     stream_topic_hash: hash_util.by_stream_topic_url,
 
@@ -131,5 +82,5 @@ export const get_helpers = (): MarkdownHelpers => ({
     get_realm_emoji_url: emoji.get_realm_emoji_url,
 
     // linkifiers
-    get_linkifier_map: () => abstract_map(linkifiers.get_linkifier_map()),
+    get_linkifier_map: () => linkifiers.get_linkifier_map(),
 });

--- a/web/src/marked.js.d.ts
+++ b/web/src/marked.js.d.ts
@@ -1,0 +1,36 @@
+import type {ParseOptions} from "./markdown";
+
+export class Renderer {
+    code: (code: string) => string;
+    link: (href: string, title: string, text: string) => void;
+    br: () => string;
+}
+
+type RegExpOrStub = RegExp | (() => boolean);
+
+type MarkedOptions = ParseOptions & {
+    userMentionHandler: (mention: string, silently: boolean) => string | undefined;
+    groupMentionHandler: (name: string, silently: boolean) => string | undefined;
+    silencedMentionHandler: (quote: string) => string;
+};
+
+type MarkedStub = {
+    (): (src: string, opt: MarkedOptions) => string | undefined;
+    Lexer: {
+        rules: {
+            tables: Record<string, RegExpOrStub>;
+        };
+    };
+    InlineLexer: {
+        rules: {
+            zulip: Record<string, RegExpOrStub>;
+        };
+    };
+    Renderer: Renderer;
+    stashHtml: (html: string, safe: boolean) => string;
+};
+
+declare module "web/third/marked/lib/marked" {
+    const marked_stub: MarkedStub;
+    export = marked_stub;
+}

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -236,7 +236,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
 
         const server_message_id = 127;
         override(markdown, "apply_markdown", noop);
-        override(markdown, "add_topic_links", noop);
+        override(markdown, "get_topic_links_web", noop);
 
         override_rewire(echo, "try_deliver_locally", (message_request) => {
             const local_id_float = 123.04;

--- a/web/tests/echo.test.js
+++ b/web/tests/echo.test.js
@@ -222,15 +222,15 @@ run_test("insert_local_message streams", ({override}) => {
     const local_id_float = 101.01;
 
     let apply_markdown_called = false;
-    let add_topic_links_called = false;
+    let get_topic_links_web_called = false;
     let insert_message_called = false;
 
     override(markdown, "apply_markdown", () => {
         apply_markdown_called = true;
     });
 
-    override(markdown, "add_topic_links", () => {
-        add_topic_links_called = true;
+    override(markdown, "get_topic_links_web", () => {
+        get_topic_links_web_called = true;
     });
 
     const insert_new_messages = ([message]) => {
@@ -252,7 +252,7 @@ run_test("insert_local_message streams", ({override}) => {
     echo.insert_local_message(message_request, local_id_float, insert_new_messages);
 
     assert.ok(apply_markdown_called);
-    assert.ok(add_topic_links_called);
+    assert.ok(get_topic_links_web_called);
     assert.ok(insert_message_called);
 });
 
@@ -273,7 +273,7 @@ run_test("insert_local_message direct message", ({override}) => {
     params.cross_realm_bots = [];
     people.initialize(page_params.user_id, params);
 
-    let add_topic_links_called = false;
+    let get_topic_links_web_called = false;
     let apply_markdown_called = false;
     let insert_message_called = false;
 
@@ -286,8 +286,8 @@ run_test("insert_local_message direct message", ({override}) => {
         apply_markdown_called = true;
     });
 
-    override(markdown, "add_topic_links", () => {
-        add_topic_links_called = true;
+    override(markdown, "get_topic_links_web", () => {
+        get_topic_links_web_called = true;
     });
 
     const message_request = {
@@ -298,7 +298,7 @@ run_test("insert_local_message direct message", ({override}) => {
         sender_id: 123,
     };
     echo.insert_local_message(message_request, local_id_float, insert_new_messages);
-    assert.ok(add_topic_links_called);
+    assert.ok(get_topic_links_web_called);
     assert.ok(apply_markdown_called);
     assert.ok(insert_message_called);
 });
@@ -307,7 +307,7 @@ run_test("test reify_message_id", ({override}) => {
     const local_id_float = 103.01;
 
     override(markdown, "apply_markdown", noop);
-    override(markdown, "add_topic_links", noop);
+    override(markdown, "get_topic_links_web", noop);
 
     const message_request = {
         type: "stream",

--- a/web/tests/markdown.test.js
+++ b/web/tests/markdown.test.js
@@ -263,9 +263,9 @@ test("marked_shared", () => {
             continue;
         }
 
-        const message = {raw_content: test.input};
+        let message = {raw_content: test.input};
         user_settings.translate_emoticons = test.translate_emoticons || false;
-        markdown.apply_markdown(message);
+        message = markdown.apply_markdown(message);
         const output = message.content;
         const error_message = `Failure in test: ${test.name}`;
         if (test.marked_expected_output) {
@@ -281,20 +281,20 @@ test("marked_shared", () => {
 
 test("message_flags", () => {
     let message = {raw_content: "@**Leo**"};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.ok(!message.flags.includes("mentioned"));
 
     message = {raw_content: "@**Cordelia, Lear's daughter**"};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.ok(message.flags.includes("mentioned"));
 
     message = {raw_content: "@**all**"};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.ok(message.flags.includes("stream_wildcard_mentioned"));
     assert.ok(!message.flags.includes("topic_wildcard_mentioned"));
 
     message = {raw_content: "@**topic**"};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.ok(!message.flags.includes("stream_wildcard_mentioned"));
     assert.ok(message.flags.includes("topic_wildcard_mentioned"));
 });
@@ -617,8 +617,8 @@ test("marked", () => {
         const input = test_case.input;
         const expected = test_case.expected;
 
-        const message = {raw_content: input};
-        markdown.apply_markdown(message);
+        let message = {raw_content: input};
+        message = markdown.apply_markdown(message);
         const output = message.content;
         assert.equal(output, expected);
     }
@@ -626,11 +626,11 @@ test("marked", () => {
 
 test("topic_links", () => {
     let message = {type: "stream", topic: "No links here"};
-    markdown.add_topic_links(message);
+    message.topic_links = markdown.get_topic_links_web(message.topic);
     assert.equal(message.topic_links.length, 0);
 
     message = {type: "stream", topic: "One #123 link here"};
-    markdown.add_topic_links(message);
+    message.topic_links = markdown.get_topic_links_web(message.topic);
     assert.equal(message.topic_links.length, 1);
     assert.deepEqual(message.topic_links[0], {
         url: "https://trac.example.com/ticket/123",
@@ -638,7 +638,7 @@ test("topic_links", () => {
     });
 
     message = {type: "stream", topic: "Two #123 #456 link here"};
-    markdown.add_topic_links(message);
+    message.topic_links = markdown.get_topic_links_web(message.topic);
     assert.equal(message.topic_links.length, 2);
     assert.deepEqual(message.topic_links[0], {
         url: "https://trac.example.com/ticket/123",
@@ -650,7 +650,7 @@ test("topic_links", () => {
     });
 
     message = {type: "stream", topic: "New ZBUG_123 link here"};
-    markdown.add_topic_links(message);
+    message.topic_links = markdown.get_topic_links_web(message.topic);
     assert.equal(message.topic_links.length, 1);
     assert.deepEqual(message.topic_links[0], {
         url: "https://trac2.zulip.net/ticket/123",
@@ -658,7 +658,7 @@ test("topic_links", () => {
     });
 
     message = {type: "stream", topic: "New ZBUG_123 with #456 link here"};
-    markdown.add_topic_links(message);
+    message.topic_links = markdown.get_topic_links_web(message.topic);
     assert.equal(message.topic_links.length, 2);
     assert.deepEqual(message.topic_links[0], {
         url: "https://trac2.zulip.net/ticket/123",
@@ -670,7 +670,7 @@ test("topic_links", () => {
     });
 
     message = {type: "stream", topic: "One ZGROUP_123:45 link here"};
-    markdown.add_topic_links(message);
+    message.topic_links = markdown.get_topic_links_web(message.topic);
     assert.equal(message.topic_links.length, 1);
     assert.deepEqual(message.topic_links[0], {
         url: "https://zone_45.zulip.net/ticket/123",
@@ -678,7 +678,7 @@ test("topic_links", () => {
     });
 
     message = {type: "stream", topic: "Hello https://google.com"};
-    markdown.add_topic_links(message);
+    message.topic_links = markdown.get_topic_links_web(message.topic);
     assert.equal(message.topic_links.length, 1);
     assert.deepEqual(message.topic_links[0], {
         url: "https://google.com",
@@ -686,7 +686,7 @@ test("topic_links", () => {
     });
 
     message = {type: "stream", topic: "#456 https://google.com https://github.com"};
-    markdown.add_topic_links(message);
+    message.topic_links = markdown.get_topic_links_web(message.topic);
     assert.equal(message.topic_links.length, 3);
     assert.deepEqual(message.topic_links[0], {
         url: "https://trac.example.com/ticket/456",
@@ -702,11 +702,11 @@ test("topic_links", () => {
     });
 
     message = {type: "not-stream"};
-    markdown.add_topic_links(message);
+    message.topic_links = markdown.get_topic_links_web(message.topic);
     assert.equal(message.topic_links.length, 0);
 
     message = {type: "stream", topic: "FOO_abcde;e;zulip;luxembourg;foo;23;testing"};
-    markdown.add_topic_links(message);
+    message.topic_links = markdown.get_topic_links_web(message.topic);
     assert.equal(message.topic_links.length, 1);
     assert.deepEqual(message.topic_links[0], {
         url: "https://zone_e.zulip.net/ticket/luxembourg/abcde?name=foo&chapter=23#testi",
@@ -717,20 +717,20 @@ test("topic_links", () => {
 test("message_flags", () => {
     let input = "/me is testing this";
     let message = {topic: "No links here", raw_content: input};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
 
     assert.equal(message.is_me_message, true);
     assert.ok(!message.unread);
 
     input = "/me is testing\nthis";
     message = {topic: "No links here", raw_content: input};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
 
     assert.equal(message.is_me_message, true);
 
     input = "testing this @**all** @**Cordelia, Lear's daughter**";
     message = {topic: "No links here", raw_content: input};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.equal(message.is_me_message, false);
     assert.equal(message.flags.includes("mentioned"), true);
     assert.equal(message.flags.includes("stream_wildcard_mentioned"), true);
@@ -738,7 +738,7 @@ test("message_flags", () => {
 
     input = "test @**everyone**";
     message = {topic: "No links here", raw_content: input};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.equal(message.is_me_message, false);
     assert.equal(message.flags.includes("stream_wildcard_mentioned"), true);
     assert.equal(message.flags.includes("topic_wildcard_mentioned"), false);
@@ -746,7 +746,7 @@ test("message_flags", () => {
 
     input = "test @**stream**";
     message = {topic: "No links here", raw_content: input};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.equal(message.is_me_message, false);
     assert.equal(message.flags.includes("stream_wildcard_mentioned"), true);
     assert.equal(message.flags.includes("topic_wildcard_mentioned"), false);
@@ -754,7 +754,7 @@ test("message_flags", () => {
 
     input = "test @**topic**";
     message = {topic: "No links here", raw_content: input};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.equal(message.is_me_message, false);
     assert.equal(message.flags.includes("stream_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("topic_wildcard_mentioned"), true);
@@ -762,98 +762,98 @@ test("message_flags", () => {
 
     input = "test @all";
     message = {topic: "No links here", raw_content: input};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.equal(message.flags.includes("stream_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("topic_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @everyone";
     message = {topic: "No links here", raw_content: input};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.equal(message.flags.includes("stream_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("topic_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @topic";
     message = {topic: "No links here", raw_content: input};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.equal(message.flags.includes("stream_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("topic_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @any";
     message = {topic: "No links here", raw_content: input};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.equal(message.flags.includes("stream_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("topic_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @alleycat.com";
     message = {topic: "No links here", raw_content: input};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.equal(message.flags.includes("stream_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("topic_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @*hamletcharacters*";
     message = {topic: "No links here", raw_content: input};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.equal(message.flags.includes("stream_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("topic_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("mentioned"), true);
 
     input = "test @*backend*";
     message = {topic: "No links here", raw_content: input};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.equal(message.flags.includes("stream_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("topic_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @**invalid_user**";
     message = {topic: "No links here", raw_content: input};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.equal(message.flags.includes("stream_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("topic_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @_**all**";
     message = {topic: "No links here", raw_content: input};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.equal(message.flags.includes("stream_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("topic_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "> test @**all**";
     message = {topic: "No links here", raw_content: input};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.equal(message.flags.includes("stream_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("topic_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @_**topic**";
     message = {topic: "No links here", raw_content: input};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.equal(message.flags.includes("stream_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("topic_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "> test @**topic**";
     message = {topic: "No links here", raw_content: input};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.equal(message.flags.includes("stream_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("topic_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @_*hamletcharacters*";
     message = {topic: "No links here", raw_content: input};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.equal(message.flags.includes("stream_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("topic_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("mentioned"), false);
 
     input = "> test @*hamletcharacters*";
     message = {topic: "No links here", raw_content: input};
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.equal(message.flags.includes("stream_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("topic_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("mentioned"), false);
@@ -929,9 +929,9 @@ test("parse_non_message", () => {
 });
 
 test("missing unicode emojis", ({override}) => {
-    const message = {raw_content: "\u{1F6B2}"};
+    let message = {raw_content: "\u{1F6B2}"};
 
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.equal(
         message.content,
         '<p><span aria-label="bike" class="emoji emoji-1f6b2" role="img" title="bike">:bike:</span></p>',
@@ -941,7 +941,7 @@ test("missing unicode emojis", ({override}) => {
     override(emoji_codes.codepoint_to_name, "1f6b2", undefined);
 
     markdown.initialize(markdown_config.get_helpers());
-    markdown.apply_markdown(message);
+    message = markdown.apply_markdown(message);
     assert.equal(message.content, "<p>\u{1F6B2}</p>");
 });
 

--- a/web/third/marked/lib/marked.d.ts
+++ b/web/third/marked/lib/marked.d.ts
@@ -1,4 +1,4 @@
-import type {ParseOptions} from "./markdown";
+import type {ParseOptions} from "../../../src/markdown";
 
 export class Renderer {
     code: (code: string) => string;
@@ -6,7 +6,9 @@ export class Renderer {
     br: () => string;
 }
 
-type RegExpOrStub = RegExp | (() => boolean);
+export type RegExpOrStub = RegExp | {
+    exec: () => boolean;
+};
 
 type MarkedOptions = ParseOptions & {
     userMentionHandler: (mention: string, silently: boolean) => string | undefined;
@@ -15,7 +17,7 @@ type MarkedOptions = ParseOptions & {
 };
 
 type MarkedStub = {
-    (): (src: string, opt: MarkedOptions) => string | undefined;
+    (src: string, opt: MarkedOptions): string | undefined;
     Lexer: {
         rules: {
             tables: Record<string, RegExpOrStub>;
@@ -26,11 +28,10 @@ type MarkedStub = {
             zulip: Record<string, RegExpOrStub>;
         };
     };
-    Renderer: Renderer;
+    Renderer: typeof Renderer;
     stashHtml: (html: string, safe: boolean) => string;
 };
 
-declare module "web/third/marked/lib/marked" {
-    const marked_stub: MarkedStub;
-    export = marked_stub;
-}
+
+declare const marked_stub: MarkedStub;
+export default marked_stub;


### PR DESCRIPTION
- I have moved the declaration file for `marked.js` to it's correct place i.e inside `third` directory.
- Used correct syntax in the declaration file to export types.
- Modified some incorrect type definitions.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
