### PR TITLE
[ai] bootstrap_typeahead: Drive query updates from the input event.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -32,12 +32,12 @@
  *
  * 2. Custom selection triggers:
  *
- *   This adds support for completing a typeahead on custom keyup input. By
+ *   This adds support for completing a typeahead on custom keydown input. By
  *   default, we only support Tab and Enter to complete a typeahead, but we
  *   have use cases where we want to complete using custom characters like: >.
  *
  *   If `this.trigger_selection` returns true, we complete the typeahead and
- *   pass the keyup event to the updater.
+ *   pass the keydown event to the updater.
  *
  *   Our custom changes include all mentions of this.trigger_selection.
  *
@@ -99,9 +99,9 @@
  *   Since it's in the right part of the DOM, we don't need to do
  *   the manual positioning in the show() function.
  *
- * 11. Add `openInputFieldOnKeyUp` option:
+ * 11. Add `openInputFieldOnInput` option:
  *
- *   If the typeahead isn't shown yet, the `lookup` call in the keyup
+ *   If the typeahead isn't shown yet, the `lookup` call in the input
  *   handler will open it. Here we make a callback to the input field
  *   before we open the lookahead in case it needs to make UI changes first
  *   (e.g. widening the search bar).
@@ -249,7 +249,7 @@ export class Typeahead<ItemType extends string | object> {
     select_on_escape_condition: () => boolean;
     // Used to clear tooltip instances attached to typeahead container.
     clear_typeahead_tooltip: (() => void) | undefined;
-    openInputFieldOnKeyUp: (() => void) | undefined;
+    openInputFieldOnInput: (() => void) | undefined;
     closeInputFieldOnHide: (() => void) | undefined;
     helpOnEmptyStrings: boolean;
     tabIsEnter: boolean;
@@ -305,7 +305,7 @@ export class Typeahead<ItemType extends string | object> {
         this.stopAdvance = options.stopAdvance ?? false;
         this.select_on_escape_condition = options.select_on_escape_condition ?? (() => false);
         this.advanceKeys = options.advanceKeys ?? [];
-        this.openInputFieldOnKeyUp = options.openInputFieldOnKeyUp;
+        this.openInputFieldOnInput = options.openInputFieldOnInput;
         this.closeInputFieldOnHide = options.closeInputFieldOnHide;
         this.tabIsEnter = options.tabIsEnter ?? true;
         this.helpOnEmptyStrings = options.helpOnEmptyStrings ?? false;
@@ -678,6 +678,7 @@ export class Typeahead<ItemType extends string | object> {
             .on("blur", this.blur.bind(this))
             .on("keypress", this.keypress.bind(this))
             .on("keyup", this.keyup.bind(this))
+            .on("input", this.input.bind(this))
             .on("click", this.element_click.bind(this))
             .on("keydown", this.keydown.bind(this))
             .on("typeahead.refreshPosition", this.refreshPosition.bind(this));
@@ -699,7 +700,7 @@ export class Typeahead<ItemType extends string | object> {
     unlisten(): void {
         this.hide();
         this.$container.remove();
-        const events = ["blur", "keydown", "keyup", "keypress", "click"];
+        const events = ["blur", "keydown", "keyup", "keypress", "input", "click"];
         for (const event of events) {
             $(this.input_element.$element).off(event);
         }
@@ -762,6 +763,9 @@ export class Typeahead<ItemType extends string | object> {
     }
 
     keydown(e: JQuery.KeyDownEvent): void {
+        // Any key interaction should give keyboard priority over the
+        // mouse for selecting the currently highlighted typeahead item.
+        this.mouse_moved_since_typeahead = false;
         if (this.trigger_selection(e)) {
             if (!this.shown) {
                 return;
@@ -784,17 +788,14 @@ export class Typeahead<ItemType extends string | object> {
     }
 
     keyup(e: JQuery.KeyUpEvent): void {
-        this.mouse_moved_since_typeahead = false;
-        // NOTE: Ideally we can ignore meta keyup calls here but
-        // it's better to just trigger the lookup call to update the list in case
-        // it did modify the query. For example, `Command + delete` on Mac
-        // doesn't trigger a keyup event but when `Command` is released, it
-        // triggers a keyup event which correctly updates the list.
+        // This handler only deals with navigation/selection keys. Query
+        // updates from typing are driven by the `input` event handler
+        // below, which fires only when the input's value actually
+        // changes -- so it naturally ignores stray keyups from keys
+        // whose keydown fired on a different element (e.g., the Tab or
+        // Shift keyup that lands here when focus moves into a typeahead
+        // input via keyboard navigation).
         switch (e.key) {
-            case "ArrowDown":
-            case "ArrowUp":
-                break;
-
             case "Tab":
                 // If the typeahead is not shown or tabIsEnter option is not set, do nothing and return
                 if (!this.tabIsEnter || !this.shown) {
@@ -834,31 +835,26 @@ export class Typeahead<ItemType extends string | object> {
                 break;
 
             default:
-                // to stop typeahead from showing up momentarily
-                // when shift + tabbing to the topic field
-                if (
-                    e.key === "Shift" &&
-                    the(this.input_element.$element).id === "stream_message_recipient_topic"
-                ) {
-                    return;
-                }
-                if (this.openInputFieldOnKeyUp !== undefined && !this.shown) {
-                    // If the typeahead isn't shown yet, the `lookup` call will open it.
-                    // Here we make a callback to the input field before we open the
-                    // lookahead in case it needs to make UI changes first (e.g. widening
-                    // the search bar).
-                    this.openInputFieldOnKeyUp();
-                }
-                if (e.key === "Backspace") {
-                    this.lookup(this.hideOnEmptyAfterBackspace);
-                    return;
-                }
-                this.lookup(false);
+                return;
         }
 
         this.maybeStopAdvance(e);
 
         e.preventDefault();
+    }
+
+    input(e: JQuery.TriggeredEvent): void {
+        if (this.openInputFieldOnInput !== undefined && !this.shown) {
+            // If the typeahead isn't shown yet, the `lookup` call will open it.
+            // Here we make a callback to the input field before we open the
+            // lookahead in case it needs to make UI changes first (e.g. widening
+            // the search bar).
+            this.openInputFieldOnInput();
+        }
+        const input_event = e.originalEvent;
+        const is_backspace =
+            input_event instanceof InputEvent && input_event.inputType === "deleteContentBackward";
+        this.lookup(is_backspace ? this.hideOnEmptyAfterBackspace : false);
     }
 
     blur(e: JQuery.BlurEvent): void {
@@ -966,7 +962,7 @@ type TypeaheadOptions<ItemType> = {
     matcher?: (item: ItemType, query: string) => boolean;
     on_escape?: () => void;
     clear_typeahead_tooltip?: () => void;
-    openInputFieldOnKeyUp?: () => void;
+    openInputFieldOnInput?: () => void;
     option_label?: (matching_items: ItemType[], item: ItemType) => string | false;
     non_tippy_parent_element?: string;
     sorter: (items: ItemType[], query: string) => ItemType[];

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -269,7 +269,7 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
             exit_search({keep_search_narrow_open: false});
         },
         tabIsEnter: true,
-        openInputFieldOnKeyUp(): void {
+        openInputFieldOnInput(): void {
             if ($(".navbar-search.expanded").length === 0) {
                 open_search_bar_and_close_narrow_description();
             }


### PR DESCRIPTION
Written with Claude, still needs to be tested. Alternative to [bootstrap_typeahead: Ignore keyup events without a prior keydown.](https://github.com/zulip/zulip/pull/32466/changes/61aa1753d351ec75dae7cb374b20df2d4037659e) in https://github.com/zulip/zulip/pull/32466

---

Previously, the keyup handler was responsible for both navigation (Tab/Enter/Escape selection) and refreshing the query after the user typed. Using keyup for the latter caused trouble when keyboard focus moved between elements mid-keystroke: the keydown fires on the old element and the keyup on the newly focused one. For a typeahead input that opens on focus, the stray Tab or Shift keyup landed in the default branch and interfered with the just-opened typeahead, which is why we previously had a special case for Shift on the topic field.

We now listen for the `input` event, which fires only when the input's value actually changes. Focus-transition keyups no longer reach the query-update path at all, so the Shift-on-topic workaround is no longer needed, and the long-standing NOTE about Command+Delete on Mac (which doesn't emit a keyup for Delete) also goes away -- `input` fires directly on the deletion. Backspace is detected via `InputEvent.inputType === "deleteContentBackward"` to preserve the existing `hideOnEmptyAfterBackspace` behavior.

`mouse_moved_since_typeahead` is reset in keydown now, so it still runs once per key interaction regardless of whether that keystroke produces a value change.

The `openInputFieldOnKeyUp` option is renamed to
`openInputFieldOnInput` to match the new event.
